### PR TITLE
Normalize datetimes

### DIFF
--- a/tests/TreeHouse/EntityMerger/EntityMergerTest.php
+++ b/tests/TreeHouse/EntityMerger/EntityMergerTest.php
@@ -308,4 +308,23 @@ class EntityMergerTest extends WebTestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testMergeNormalizesDateTimes()
+    {
+        $available = new \DateTime('2015-08-15', new DateTimeZone('UTC'));
+
+        $original = new Vacancy();
+        $original->setDatetimeAvailable($available);
+
+        $update = new Vacancy();
+        $update->setDatetimeAvailable(new \DateTime('2015-08-15', new DateTimeZone('+00:00'))); // mind the timezone
+
+        $expected = new Vacancy();
+        $expected->setDatetimeAvailable($available);
+
+        $result = $this->merger->merge($original, $update);
+
+        $this->assertSame($original->getDatetimeAvailable(), $available);
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TreeHouse/EntityMerger/EntityMergerTest.php
+++ b/tests/TreeHouse/EntityMerger/EntityMergerTest.php
@@ -317,7 +317,13 @@ class EntityMergerTest extends WebTestCase
         $original->setDatetimeAvailable($available);
 
         $update = new Vacancy();
-        $update->setDatetimeAvailable(new \DateTime('2015-08-15', new DateTimeZone('+00:00'))); // mind the timezone
+        // create a datetime with different timezone notation:
+        // class DateTime#1915 (3) {
+        //  public $date => string(26) "2015-05-18 00:00:00.000000"
+        //  public $timezone_type => int(1)
+        //  public $timezone => string(6) "+00:00"   <-------------- different timezone, not "UTC"
+        //}
+        $update->setDatetimeAvailable(new \DateTime('2015-08-15T00:00:00+00:00'));
 
         $expected = new Vacancy();
         $expected->setDatetimeAvailable($available);

--- a/tests/TreeHouse/IntegrationBundle/Entity/Vacancy.php
+++ b/tests/TreeHouse/IntegrationBundle/Entity/Vacancy.php
@@ -85,6 +85,17 @@ class Vacancy
     protected $functionTags;
 
     /**
+     * datetime the vacancy is published/found/opened
+     * Indicates when the applicant can start on the job
+     *
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime")
+     * @Serializer\Groups({"publish_vacancy", "api_vacancy_details"})
+     */
+    protected $datetimeAvailable;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -275,5 +286,25 @@ class Vacancy
     public function setProviderBranch($providerBranch)
     {
         $this->providerBranch = $providerBranch;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDatetimeAvailable()
+    {
+        return $this->datetimeAvailable;
+    }
+
+    /**
+     * @param \DateTime $datetimeAvailable
+     *
+     * @return $this
+     */
+    public function setDatetimeAvailable($datetimeAvailable)
+    {
+        $this->datetimeAvailable = $datetimeAvailable;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Prevents doctrine from detecting a change in value, just because the time zone is a little different format, but actually still the same ("UTC" vs "+00:00").
